### PR TITLE
Move search bar to navbar

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -84,7 +84,7 @@ const Navbar = observer(() => {
 								key={page.href}
 								href={page.href}
 								display='block'
-								mr={page.href === PAGES.at(-1)?.href ? '0' : '6'}
+								mr={6}
 								mt={{base: 4, md: 0}}
 								color='inherit'
 							>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -83,7 +83,7 @@ const Navbar = observer(() => {
 							key={page.href}
 							href={page.href}
 							display='block'
-							mr={6}
+							mr={page.href === PAGES.at(-1).href ? '0' : '6'}
 							mt={{base: 4, md: 0}}
 							color='inherit'
 						>
@@ -96,6 +96,7 @@ const Navbar = observer(() => {
 			<Box
 				display={{base: isOpen ? 'block' : 'none', md: 'flex'}}
 				width={{base: 'full', md: 'auto'}}
+				mt={{base: 4, md: 0}}
 				alignItems='center'
 				flexGrow={1}
 			>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -101,15 +101,12 @@ const Navbar = observer(() => {
 				mt={{base: 4, md: 0}}
 				alignItems='center'
 				flex={{lg: 1}}
+				visibility={(shouldShowCourseSearch || shouldShowTransferSearch) ? 'visible' : 'hidden'}
 			>
 				{
-					shouldShowCourseSearch && (
+					shouldShowCourseSearch ? (
 						<CoursesSearchBar/>
-					)
-				}
-
-				{
-					shouldShowTransferSearch && (
+					) : (
 						<DefaultSearchBar
 							innerRef={transferSearchBarRef}
 							isEnabled={store.transferCoursesState.hasData}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -50,8 +50,8 @@ const Navbar = observer(() => {
 		store.apiState.setSelectedTerm(JSON.parse(event.target.value) as IPotentialFutureTerm);
 	}, [store]);
 
-	const searchBarRef = useRef<HTMLDivElement>(null);
-	const handleSearchChange = useCallback((newValue: string) => {
+	const transferSearchBarRef = useRef<HTMLDivElement>(null);
+	const handleTransferSearchChange = useCallback((newValue: string) => {
 		store.transferCoursesState.setSearchValue(newValue);
 	}, [store.transferCoursesState]);
 
@@ -109,11 +109,11 @@ const Navbar = observer(() => {
 				{
 					shouldShowTransferSearch && (
 						<DefaultSearchBar
-							innerRef={searchBarRef}
+							innerRef={transferSearchBarRef}
 							isEnabled={store.transferCoursesState.hasData}
 							placeholder='Search by state, college, subject, or anything else...'
 							value={store.transferCoursesState.searchValue}
-							onChange={handleSearchChange}
+							onChange={handleTransferSearchChange}
 						/>
 					)
 				}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useCallback} from 'react';
+import React, {useState, useCallback, useRef} from 'react';
 import {Flex, Box, Select, IconButton, HStack} from '@chakra-ui/react';
 import {CloseIcon, HamburgerIcon} from '@chakra-ui/icons';
 import {useRouter} from 'next/router';
@@ -10,6 +10,8 @@ import {type IPotentialFutureTerm} from 'src/lib/types';
 import toTitleCase from 'src/lib/to-title-case';
 import ColorModeToggle from './color-mode-toggle';
 import Link from './link';
+import CoursesSearchBar from './search-bar/courses';
+import DefaultSearchBar from './search-bar/default';
 
 const PAGES = [
 	{
@@ -48,7 +50,15 @@ const Navbar = observer(() => {
 		store.apiState.setSelectedTerm(JSON.parse(event.target.value) as IPotentialFutureTerm);
 	}, [store]);
 
+	const searchBarRef = useRef<HTMLDivElement>(null);
+	const handleSearchChange = useCallback((newValue: string) => {
+		store.transferCoursesState.setSearchValue(newValue);
+	}, [store.transferCoursesState]);
+
 	const shouldShowTermSelector = PATHS_THAT_REQUIRE_TERM_SELECTOR.has(router.pathname);
+
+	const shouldShowCourseSearch = PAGES[0].href === router.pathname;
+	const shouldShowTransferSearch = PAGES[1].href === router.pathname;
 
 	return (
 		<Flex align='center' justify='space-between' wrap='wrap' p={4} as='nav' mb={8}>
@@ -66,7 +76,6 @@ const Navbar = observer(() => {
 				display={{base: isOpen ? 'block' : 'none', md: 'flex'}}
 				width={{base: 'full', md: 'auto'}}
 				alignItems='center'
-				flexGrow={1}
 			>
 				{
 					PAGES.map(page => (
@@ -81,6 +90,31 @@ const Navbar = observer(() => {
 							{page.label}
 						</Link>
 					))
+				}
+			</Box>
+
+			<Box
+				display={{base: isOpen ? 'block' : 'none', md: 'flex'}}
+				width={{base: 'full', md: 'auto'}}
+				alignItems='center'
+				flexGrow={1}
+			>
+				{
+					shouldShowCourseSearch && (
+						<CoursesSearchBar/>
+					)
+				}
+
+				{
+					shouldShowTransferSearch && (
+						<DefaultSearchBar
+							innerRef={searchBarRef}
+							isEnabled={store.transferCoursesState.hasData}
+							placeholder='Search by state, college, subject, or anything else...'
+							value={store.transferCoursesState.searchValue}
+							onChange={handleSearchChange}
+						/>
+					)
 				}
 			</Box>
 

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -62,7 +62,7 @@ const Navbar = observer(() => {
 
 	return (
 		<Flex align='center' justify='space-between' wrap='wrap' p={4} as='nav' mb={8}>
-			<Flex flex={{lg: 1}}>
+			<Flex flex={{lg: 1}} wrap='wrap' width='100%'>
 				<Box width='40px' height='40px' borderRadius='full' overflow='hidden' mr={5}>
 					<Logo/>
 				</Box>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -62,43 +62,45 @@ const Navbar = observer(() => {
 
 	return (
 		<Flex align='center' justify='space-between' wrap='wrap' p={4} as='nav' mb={8}>
-			<Box width='40px' height='40px' borderRadius='full' overflow='hidden' mr={5}>
-				<Logo/>
-			</Box>
+			<Flex flex={{lg: 1}}>
+				<Box width='40px' height='40px' borderRadius='full' overflow='hidden' mr={5}>
+					<Logo/>
+				</Box>
 
-			<Box display={{base: 'block', md: 'none'}} ml='auto' onClick={handleToggle}>
-				<IconButton aria-label={isOpen ? 'Close navbar' : 'Open navbar'}>
-					{isOpen ? <CloseIcon/> : <HamburgerIcon/>}
-				</IconButton>
-			</Box>
+				<Box display={{base: 'block', md: 'none'}} ml='auto' onClick={handleToggle}>
+					<IconButton aria-label={isOpen ? 'Close navbar' : 'Open navbar'}>
+						{isOpen ? <CloseIcon/> : <HamburgerIcon/>}
+					</IconButton>
+				</Box>
 
-			<Box
-				display={{base: isOpen ? 'block' : 'none', md: 'flex'}}
-				width={{base: 'full', md: 'auto'}}
-				alignItems='center'
-			>
-				{
-					PAGES.map(page => (
-						<Link
-							key={page.href}
-							href={page.href}
-							display='block'
-							mr={page.href === PAGES.at(-1).href ? '0' : '6'}
-							mt={{base: 4, md: 0}}
-							color='inherit'
-						>
-							{page.label}
-						</Link>
-					))
-				}
-			</Box>
+				<Box
+					display={{base: isOpen ? 'block' : 'none', md: 'flex'}}
+					width={{base: 'full', md: 'auto'}}
+					alignItems='center'
+				>
+					{
+						PAGES.map(page => (
+							<Link
+								key={page.href}
+								href={page.href}
+								display='block'
+								mr={page.href === PAGES.at(-1)?.href ? '0' : '6'}
+								mt={{base: 4, md: 0}}
+								color='inherit'
+							>
+								{page.label}
+							</Link>
+						))
+					}
+				</Box>
+			</Flex>
 
 			<Box
 				display={{base: isOpen ? 'block' : 'none', md: 'flex'}}
 				width={{base: 'full', md: 'auto'}}
 				mt={{base: 4, md: 0}}
 				alignItems='center'
-				flexGrow={1}
+				flex={{lg: 1}}
 			>
 				{
 					shouldShowCourseSearch && (
@@ -121,6 +123,8 @@ const Navbar = observer(() => {
 
 			<HStack
 				display={{base: isOpen ? 'flex' : 'none', md: 'flex'}}
+				flex={{lg: 1}}
+				justifyContent='end'
 				mt={{base: 4, md: 0}}
 			>
 

--- a/src/components/search-bar/default.tsx
+++ b/src/components/search-bar/default.tsx
@@ -58,7 +58,7 @@ const DefaultSearchBar = observer((props: SearchBarProps) => {
 	}, []);
 
 	return (
-		<Container ref={props.innerRef} maxW='100%'>
+		<Container ref={props.innerRef}>
 			<InputGroup boxShadow='md' borderRadius='md' size='lg'>
 				<InputLeftElement pointerEvents='none'>
 					<Search2Icon color='gray.300'/>

--- a/src/components/search-bar/default.tsx
+++ b/src/components/search-bar/default.tsx
@@ -106,7 +106,7 @@ const DefaultSearchBar = observer((props: SearchBarProps) => {
 			</InputGroup>
 
 			{props.children && (
-				<HStack mt={3} w='100%' justifyContent='center' mb={'-45px'}>
+				<HStack mt={3} w='100%' justifyContent='center' mb={{base: '0', md: '-45px'}}>
 					<Text>
 						hold <Kbd>/</Kbd> to see
 					</Text>

--- a/src/components/search-bar/default.tsx
+++ b/src/components/search-bar/default.tsx
@@ -58,7 +58,7 @@ const DefaultSearchBar = observer((props: SearchBarProps) => {
 	}, []);
 
 	return (
-		<Container ref={props.innerRef}>
+		<Container ref={props.innerRef} paddingX={{md: 0}}>
 			<InputGroup boxShadow='md' borderRadius='md' size='lg'>
 				<InputLeftElement pointerEvents='none'>
 					<Search2Icon color='gray.300'/>

--- a/src/components/search-bar/default.tsx
+++ b/src/components/search-bar/default.tsx
@@ -58,7 +58,7 @@ const DefaultSearchBar = observer((props: SearchBarProps) => {
 	}, []);
 
 	return (
-		<Container ref={props.innerRef}>
+		<Container ref={props.innerRef} maxW='100%'>
 			<InputGroup boxShadow='md' borderRadius='md' size='lg'>
 				<InputLeftElement pointerEvents='none'>
 					<Search2Icon color='gray.300'/>
@@ -106,7 +106,7 @@ const DefaultSearchBar = observer((props: SearchBarProps) => {
 			</InputGroup>
 
 			{props.children && (
-				<HStack mt={3} w='100%' justifyContent='center'>
+				<HStack mt={3} w='100%' justifyContent='center' mb={'-45px'}>
 					<Text>
 						hold <Kbd>/</Kbd> to see
 					</Text>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -115,8 +115,6 @@ const HomePage = observer(() => {
 				)}
 			</Head>
 
-			<CoursesSearchBar/>
-
 			<MainContent/>
 
 			<ErrorToaster/>

--- a/src/pages/transfer-courses.tsx
+++ b/src/pages/transfer-courses.tsx
@@ -48,14 +48,6 @@ const TransferCourses = observer(() => {
 			</Head>
 
 			<VStack spacing={12}>
-				<DefaultSearchBar
-					innerRef={searchBarRef}
-					isEnabled={transferCoursesState.hasData}
-					placeholder='Search by state, college, subject, or anything else...'
-					value={transferCoursesState.searchValue}
-					onChange={handleSearchChange}
-				/>
-
 				<TransferCoursesTable onScrollToTop={handleScrollToTop}/>
 			</VStack>
 


### PR DESCRIPTION
This moves the search bar into the navbar to save on vertical space. It also works properly on smaller screens.

![move-search](https://github.com/Michigan-Tech-Courses/frontend/assets/68570349/f6a88906-da6c-4c27-8886-4eef42cb5edd)
